### PR TITLE
Check for length of configLanguageMods

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -58,7 +58,7 @@ export function activate(context: vscode.ExtensionContext) {
 	});
 
 	let completionProvider = vscode.languages.registerCompletionItemProvider(
-		configLanguageMods || [ 'css', 'postcss' ],
+		configLanguageMods.length ? configLanguageMods : [ 'css', 'postcss' ],
 		{
 			async provideCompletionItems(document, position) {
 				let completionItems: vscode.CompletionItem[] = items;


### PR DESCRIPTION
Fixes #1 

`configLanguageMods` defaults to an empty array, which is truthy, so it is used instead of the defaults.  This change checks if the array is not empty before using it.

I verified this change by editing the extension and confirming that autocompletion starts working after the change.